### PR TITLE
add missing prefix in the example

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -754,6 +754,7 @@
 
         <pre class="example" title="Blank nodes (alternative notation)">
           @prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+          @prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
 
           # Some resource (blank node) is interested in some other resource
           # entitled "Mona Lisa" and created by Leonardo da Vinci.


### PR DESCRIPTION
In the Blank nodes (alternative notation) example, there is no `dcterms` prefix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-primer/pull/17.html" title="Last updated on Dec 10, 2024, 4:21 PM UTC (3d1983c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-primer/17/81afc3e...3d1983c.html" title="Last updated on Dec 10, 2024, 4:21 PM UTC (3d1983c)">Diff</a>