### PR TITLE
Add information about directional language-tagged strings

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -304,7 +304,7 @@
     <a data-cite="RDF12-CONCEPTS#dfn-datatype">datatype</a>, enabling them to
     be parsed and interpreted correctly.</p>
 
-    <p>String literals can optionally be associated with a <a
+    <p>Strings can optionally be associated with a <a
         data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
     For example, to clarify that the name "Leonardo da Vinci" is the English
     verison of his name, the string can be associated with the <code>en</code>
@@ -314,7 +314,7 @@
     <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>.
     </p>
 
-    <p>String literals may also optionally be associated with an initial <a>base
+    <p>Strings may also optionally be associated with an initial <a>base
     direction</a>, with a value of either <code>ltr</code> or <code>rtl</code>
     (for left-to-right and right-to-left, respectively). For example, the English
     title <q lang="en" dir="ltr">HTML &amp; CSS: Designing and Creating Websites</q>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -298,8 +298,8 @@
 
     <p><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a>
     are used to encode values, rather than identifying them by IRIs. Examples
-    of literals include strings such as "La Joconde", dates such as
-    "1990-07-04" (the 4th of July, 1990) and numbers such as "3.14159".
+    of literals include strings such as `"La Joconde"`, ISO-8601 formatted
+    dates such as `1990-07-04` and numbers such as `3.14159`.
     Literals are always associated with a
     <a data-cite="RDF12-CONCEPTS#dfn-datatype">datatype</a>, enabling them to
     be parsed and interpreted correctly.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -822,6 +822,22 @@
       The <code>a</code> shorthand is intended to match the human
       intuition about <code>rdf:type</code>. </p>
 
+      <section id="section-turtle-dirlangstring-representation">
+        <h5>Representation of strings with language and direction</h5>
+        <p>The following describes a book with its title in both English and
+        Arabic, using a language-tagged string (line 7) and a directional
+        language-tagged string (line 8):</p>
+        <pre class="example" title="Turtle" id="turtle-example">
+          <span class="linenum">01</span>    BASE   &lt;http://example.org/&gt;
+          <span class="linenum">02</span>    PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt;
+          <span class="linenum">03</span>    PREFIX dct:  &lt;http://purl.org/dc/terms/&gt;
+          <span class="linenum">05</span>
+          <span class="linenum">06</span>    &lt;books/html_and_css&gt; a bibo:Book ;
+          <span class="linenum">07</span>        dct:title "HTML &amp; CSS: Designing and Creating Websites"@en ,
+          <span class="linenum">08</span>                  "HTML و CSS: تصميم و إنشاء مواقع الويب"@ar--rtl .
+        </pre>
+      </section>
+
       <section id="section-blank-node-representation">
         <h5>Representation of blank nodes</h5>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -297,15 +297,22 @@
     <h3>Literals</h3>
 
     <p><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a>
-    are basic values that are not IRIs. Examples of literals include
-    strings such as "La Joconde", dates such as "the 4th of July, 1990"
-    and numbers such as "3.14159".
-    Literals are associated with a <a data-cite="RDF12-CONCEPTS#dfn-datatype">datatype</a>
-    enabling such values to be parsed and interpreted correctly.
-    String literals can optionally be associated with a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
-    For example, "Léonard de Vinci" could
-    be associated with the "fr" language tag and "李奥纳多·达·文西"
-    with the "zh" language tag.</p>
+    are used to encode values, rather than identifying them by IRIs. Examples
+    of literals include strings such as "La Joconde", dates such as
+    "1990-07-04" (the 4th of July, 1990) and numbers such as "3.14159".
+    Literals are always associated with a
+    <a data-cite="RDF12-CONCEPTS#dfn-datatype">datatype</a>, enabling them to
+    be parsed and interpreted correctly.</p>
+
+    <p>String literals can optionally be associated with a <a
+        data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
+    For example, to clarify that the name "Leonardo da Vinci" is the English
+    verison of his name, the string can be associated with the <code>en</code>
+    language tag, "Léonard de Vinci" with the <code>fr</code> language tag (French),
+    and "李奥纳多·达·文西" with the <code>zh</code> language tag (Chinese).
+    Such literals are called
+    <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>.
+    </p>
 
     <p>String literals may also optionally be associated with an initial <a>base
     direction</a>, with a value of either <code>ltr</code> or <code>rtl</code>

--- a/spec/index.html
+++ b/spec/index.html
@@ -305,9 +305,9 @@
     be parsed and interpreted correctly.</p>
 
     <p>Strings can optionally be associated with a <a
-        data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>.
-    For example, to clarify that the name "Leonardo da Vinci" is the English
-    verison of his name, the string can be associated with the <code>en</code>
+        data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>;
+    for example, to clarify that the name "Leonardo da Vinci" is the English
+    version of his name, the string can be associated with the <code>en</code>
     language tag, "Léonard de Vinci" with the <code>fr</code> language tag (French),
     and "李奥纳多·达·文西" with the <code>zh</code> language tag (Chinese).
     Such literals are called
@@ -316,9 +316,9 @@
 
     <p>Strings may also optionally be associated with an initial <a>base
     direction</a>, with a value of either <code>ltr</code> or <code>rtl</code>
-    (for left-to-right and right-to-left, respectively). For example, the English
+    (for left-to-right and right-to-left, respectively); for example, the English
     title <q lang="en" dir="ltr">HTML &amp; CSS: Designing and Creating Websites</q>,
-    associated with the <code>en</code> language tag and recognised as written
+    associated with the <code>en</code> language tag and recognized as written
     from left to right, would in an Arabic translation be written from right to
     left, as:
     <q lang="ar" dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب</q>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -307,6 +307,32 @@
     be associated with the "fr" language tag and "李奥纳多·达·文西"
     with the "zh" language tag.</p>
 
+    <p>String literals may also optionally be associated with an initial <a>base
+    direction</a>, with a value of either <code>ltr</code> or <code>rtl</code>
+    (for left-to-right and right-to-left, respectively). For example, the English
+    title <q lang="en" dir="ltr">HTML &amp; CSS: Designing and Creating Websites</q>,
+    associated with the <code>en</code> language tag and recognised as written
+    from left to right, would in an Arabic translation be written from right to
+    left, as:
+    <q lang="ar" dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب</q>,
+    when associated with the <code>ar</code> language tag and the
+    <code>rtl</code> initial text direction. Such literals are called
+    <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>.
+    </p>
+
+    <p class="note">Base direction is used to assist in
+    [=Unicode Bidirectional Algorithm|BIDI=] [[?I18N-Glossary]] processing.
+    Without the initial base direction, the example title above would incorrectly render
+    as:
+    <q lang="ar">HTML و CSS: تصميم و إنشاء مواقع الويب</q>.
+    This is due to the left-to-right directionality of the initial characters
+    in the encoded form, which precede the Arabic letters subsequently
+    recognised as right-to-left by the BIDI algorithm. More examples can be
+    found in the article
+    <a href="https://www.w3.org/International/articles/lang-bidi-use-cases/"
+      >Use cases for bidi and language metadata on the Web</a>.
+    </p>
+
     <!--
     <p class="note">The 2004 version of RDF contained the notion of a
     "plain literal" with no datatype. This feature has been removed, as the
@@ -1459,6 +1485,7 @@
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
+    <li>Added information about directional language-tagged strings (new in RDF 1.2).</li>
     <li>Added information about triple terms (new in RDF 1.2).</li>
   </ul>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -298,8 +298,8 @@
 
     <p><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a>
     are used to encode values, rather than identifying them by IRIs. Examples
-    of literals include strings such as `"La Joconde"`, ISO-8601 formatted
-    dates such as `1990-07-04` and numbers such as `3.14159`.
+    of literals include strings such as `"La Joconde"`, dates formatted
+    according to ISO-8601 such as `1990-07-04`, and numbers such as `3.14159`.
     Literals are always associated with a
     <a data-cite="RDF12-CONCEPTS#dfn-datatype">datatype</a>, enabling them to
     be parsed and interpreted correctly.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -834,7 +834,7 @@
         <p>The following describes a book with its title in both English and
         Arabic, using a language-tagged string (line 7) and a directional
         language-tagged string (line 8):</p>
-        <pre class="example" title="Turtle" id="turtle-example">
+        <pre class="example" title="Turtle" id="turtle-dirlangstring-example">
           <span class="linenum">01</span>    BASE   &lt;http://example.org/&gt;
           <span class="linenum">02</span>    PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt;
           <span class="linenum">03</span>    PREFIX dct:  &lt;http://purl.org/dc/terms/&gt;


### PR DESCRIPTION
This updates the introductory text on literals with some general clarifications, information about directional language-tagged strings, and adds a corresponding turtle representation of strings with language and direction.

Resolves #19.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-primer/pull/35.html" title="Last updated on Jul 11, 2025, 10:26 PM UTC (12991ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-primer/35/331997c...12991ef.html" title="Last updated on Jul 11, 2025, 10:26 PM UTC (12991ef)">Diff</a>