### PR TITLE
named graphs are no longer 'recent' :->

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -454,7 +454,7 @@
     <h3>Multiple graphs</h3>
 
     <p>RDF provides a mechanism to group RDF statements in multiple
-    graphs and associate such graphs with an IRI . Multiple graphs are a recent extension of the RDF
+    graphs and associate such graphs with an IRI . Multiple graphs where introduced by RDF 1.1 in the RDF
     data model. In practice, RDF tool builders and data managers
     needed a mechanism to talk about subsets of a collection of
     triples. Multiple graphs were first introduced in the RDF query

--- a/spec/index.html
+++ b/spec/index.html
@@ -454,8 +454,8 @@
     <h3>Multiple graphs</h3>
 
     <p>RDF provides a mechanism to group RDF statements in multiple
-    graphs and associate such graphs with an IRI. Multiple graphs were introduced to the RDF
-    data model by RDF 1.1. In practice, RDF tool builders and data managers
+    graphs and associate such graphs with an IRI. Multiple graphs were introduced to
+    the RDF data model by RDF 1.1. In practice, RDF tool builders and data managers
     needed a mechanism to talk about subsets of a collection of
     triples. Multiple graphs were first introduced in the RDF query
     language, SPARQL. The RDF data model was therefore extended with a notion of

--- a/spec/index.html
+++ b/spec/index.html
@@ -454,8 +454,8 @@
     <h3>Multiple graphs</h3>
 
     <p>RDF provides a mechanism to group RDF statements in multiple
-    graphs and associate such graphs with an IRI . Multiple graphs where introduced by RDF 1.1 in the RDF
-    data model. In practice, RDF tool builders and data managers
+    graphs and associate such graphs with an IRI. Multiple graphs were introduced to the RDF
+    data model by RDF 1.1. In practice, RDF tool builders and data managers
     needed a mechanism to talk about subsets of a collection of
     triples. Multiple graphs were first introduced in the RDF query
     language SPARQL. The RDF data model was therefore extended with a notion of

--- a/spec/index.html
+++ b/spec/index.html
@@ -458,7 +458,7 @@
     data model by RDF 1.1. In practice, RDF tool builders and data managers
     needed a mechanism to talk about subsets of a collection of
     triples. Multiple graphs were first introduced in the RDF query
-    language SPARQL. The RDF data model was therefore extended with a notion of
+    language, SPARQL. The RDF data model was therefore extended with a notion of
     multiple graphs that is closely aligned with SPARQL.</p>
 
     <p>Multiple graphs in


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-primer/pull/38.html" title="Last updated on Apr 16, 2026, 5:14 PM UTC (56bde23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-primer/38/c46f18b...56bde23.html" title="Last updated on Apr 16, 2026, 5:14 PM UTC (56bde23)">Diff</a>